### PR TITLE
refactor: implement grayscale crop

### DIFF
--- a/src/utils/convert.ts
+++ b/src/utils/convert.ts
@@ -1,0 +1,31 @@
+import { strict as assert } from 'assert'
+import { createImageData } from 'canvas'
+import { makeImageTransform } from './makeImageTransform'
+
+/**
+ * Converts an image to an RGBA image.
+ */
+export const toRGBA = makeImageTransform(grayToRGBA, (imageData) => imageData)
+
+/**
+ * Converts a grayscale image to an RGBA image.
+ */
+export function grayToRGBA({ data: src, width, height }: ImageData): ImageData {
+  assert.equal(src.length, width * height, 'expected a grayscale image')
+
+  const dst = new Uint8ClampedArray(width * height * 4)
+
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const srcOffset = x + y * width
+      const dstOffset = srcOffset << 2
+
+      dst[dstOffset] = src[srcOffset]
+      dst[dstOffset + 1] = src[srcOffset]
+      dst[dstOffset + 2] = src[srcOffset]
+      dst[dstOffset + 3] = 255
+    }
+  }
+
+  return createImageData(dst, width, height)
+}

--- a/src/utils/crop.test.ts
+++ b/src/utils/crop.test.ts
@@ -1,0 +1,30 @@
+import crop from './crop'
+
+test('crop center (gray)', () => {
+  const imageData = {
+    data: Uint8ClampedArray.of(0, 0, 0, 0, 1, 0, 0, 0, 0),
+    width: 3,
+    height: 3,
+  }
+
+  const { data, ...size } = crop(imageData, { x: 1, y: 1, width: 1, height: 1 })
+  expect([...data]).toEqual([1])
+  expect(size).toEqual({ width: 1, height: 1 })
+})
+
+test('crop center (rgba)', () => {
+  const imageData = {
+    data: Uint8ClampedArray.of(0, 0, 0, 255, 1, 0, 0, 255),
+    width: 2,
+    height: 1,
+  }
+
+  const { data, width, height } = crop(imageData, {
+    x: 1,
+    y: 0,
+    width: 1,
+    height: 1,
+  })
+  expect([...data]).toEqual([1, 0, 0, 255])
+  expect({ width, height }).toEqual({ width: 1, height: 1 })
+})

--- a/src/utils/crop.ts
+++ b/src/utils/crop.ts
@@ -1,9 +1,71 @@
-import { createCanvas } from 'canvas'
+import { createImageData } from 'canvas'
 import { Rect } from '../types'
+import { makeImageTransform } from './makeImageTransform'
 
-export default function crop(imageData: ImageData, bounds: Rect): ImageData {
-  const canvas = createCanvas(bounds.width, bounds.height)
-  const context = canvas.getContext('2d')
-  context.putImageData(imageData, -bounds.x, -bounds.y)
-  return context.getImageData(0, 0, bounds.width, bounds.height)
+/**
+ * Returns a new image cropped to the specified bounds.
+ */
+export default makeImageTransform(gray, rgba)
+
+/**
+ * Returns a new grayscale image cropped to the specified bounds.
+ */
+export function gray(
+  { data: src, width: srcWidth }: ImageData,
+  bounds: Rect
+): ImageData {
+  const dst = new Uint8ClampedArray(bounds.width * bounds.height)
+  const {
+    x: srcXOffset,
+    y: srcYOffset,
+    width: dstWidth,
+    height: dstHeight,
+  } = bounds
+
+  for (let y = 0; y < dstHeight; y += 1) {
+    const srcY = srcYOffset + y
+
+    for (let x = 0; x < dstWidth; x += 1) {
+      const srcX = srcXOffset + x
+      const srcOffset = srcX + srcY * srcWidth
+      const dstOffset = x + y * dstWidth
+
+      dst[dstOffset] = src[srcOffset]
+    }
+  }
+
+  return { data: dst, width: dstWidth, height: dstHeight }
+}
+
+/**
+ * Returns a new RGBA image cropped to the specified bounds.
+ */
+export function rgba(
+  { data: src, width: srcWidth }: ImageData,
+  bounds: Rect
+): ImageData {
+  const dst = new Uint8ClampedArray(bounds.width * bounds.height * 4)
+  const {
+    x: srcXOffset,
+    y: srcYOffset,
+    width: dstWidth,
+    height: dstHeight,
+  } = bounds
+
+  for (let y = 0; y < dstHeight; y += 1) {
+    const srcY = srcYOffset + y
+
+    for (let x = 0; x < dstWidth; x += 1) {
+      const srcX = srcXOffset + x
+      const srcOffset = (srcX + srcY * srcWidth) << 2
+      const dstOffset = (x + y * dstWidth) << 2
+
+      dst[dstOffset] = src[srcOffset]
+      dst[dstOffset + 1] = src[srcOffset + 1]
+      dst[dstOffset + 2] = src[srcOffset + 2]
+      dst[dstOffset + 3] = src[srcOffset + 3]
+    }
+  }
+
+  return createImageData(dst, dstWidth, dstHeight)
 }

--- a/src/utils/makeImageTransform.ts
+++ b/src/utils/makeImageTransform.ts
@@ -1,0 +1,25 @@
+export type ImageTransform<A extends unknown[], R> = (
+  imageData: ImageData,
+  ...args: A
+) => R
+
+export function makeImageTransform<A extends unknown[], R>(
+  gray: ImageTransform<A, R>,
+  rgba: ImageTransform<A, R>
+): ImageTransform<A, R> {
+  return (imageData: ImageData, ...args: A): R => {
+    const channels =
+      imageData.data.length / (imageData.width * imageData.height)
+
+    switch (channels) {
+      case 1:
+        return gray(imageData, ...args)
+
+      case 4:
+        return rgba(imageData, ...args)
+
+      default:
+        throw new Error(`unexpected ${channels}-channel image`)
+    }
+  }
+}

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,6 +1,7 @@
 import { createCanvas } from 'canvas'
 import { promises as fs } from 'fs'
 import { Rect } from '../src/types'
+import { toRGBA } from '../src/utils/convert'
 
 export async function writeImageToFile(
   imageData: ImageData,
@@ -12,6 +13,6 @@ export async function writeImageToFile(
     bounds?.height ?? imageData.height
   )
   const context = canvas.getContext('2d')
-  context.putImageData(imageData, -(bounds?.x ?? 0), -(bounds?.y ?? 0))
+  context.putImageData(toRGBA(imageData), -(bounds?.x ?? 0), -(bounds?.y ?? 0))
   await fs.writeFile(filePath, canvas.toBuffer())
 }


### PR DESCRIPTION
This makes it possible for us to crop either grayscale or RGBA images without requiring a round-trip through RGBA.

Also ensures that `writeImageFile` always calls `putImageData` with an RGBA image, since otherwise it segfaults.