### PR TITLE
refactor: make `vh` flip operate inline

### DIFF
--- a/src/Interpreter.test.ts
+++ b/src/Interpreter.test.ts
@@ -720,9 +720,10 @@ test('upside-down ballot', async () => {
     await templatePage2.metadata()
   )
 
-  const { ballot } = await interpreter.interpretBallot(
-    flipVH(await yvonneDavis.imageData())
-  )
+  const imageData = await yvonneDavis.imageData()
+  flipVH(imageData)
+
+  const { ballot } = await interpreter.interpretBallot(imageData)
   expect(ballot.votes).toMatchInlineSnapshot(`
     Object {
       "texas-house-district-111": Array [

--- a/src/Interpreter.ts
+++ b/src/Interpreter.ts
@@ -312,7 +312,7 @@ export default class Interpreter {
     })
     metadata = detectResult.metadata
     if (detectResult.flipped) {
-      imageData = flipVH(imageData)
+      flipVH(imageData)
     }
 
     return { imageData, metadata }

--- a/src/metadata.test.ts
+++ b/src/metadata.test.ts
@@ -73,7 +73,11 @@ test('custom QR code reader', async () => {
 })
 
 test('upside-down ballot images', async () => {
-  expect(await detect(flipVH(await templatePage1.imageData()))).toEqual({
+  const imageData = await templatePage1.imageData()
+
+  flipVH(imageData)
+
+  expect(await detect(imageData)).toEqual({
     metadata: {
       ballotStyleId: '77',
       precinctId: '42',

--- a/src/utils/flip.test.ts
+++ b/src/utils/flip.test.ts
@@ -3,12 +3,14 @@ import { vh } from './flip'
 
 test('vh does nothing to 1x1 image (rgba)', () => {
   const image = createImageData(Uint8ClampedArray.of(42, 42, 42, 255), 1, 1)
-  expect([...vh(image).data]).toEqual([...image.data])
+  vh(image)
+  expect([...image.data]).toEqual([42, 42, 42, 255])
 })
 
 test('vh does nothing to 1x1 image (gray)', () => {
   const image = createImageData(Uint8ClampedArray.of(42), 1, 1)
-  expect([...vh(image).data]).toEqual([...image.data])
+  vh(image)
+  expect([...image.data]).toEqual([42])
 })
 
 test('vh flips images vertically and horizontally (rgba)', () => {
@@ -36,7 +38,9 @@ test('vh flips images vertically and horizontally (rgba)', () => {
     3
   )
 
-  expect([...vh(image).data]).toEqual([
+  vh(image)
+
+  expect([...image.data]).toEqual([
     ...[...pixels[2][1], ...pixels[2][0]],
     ...[...pixels[1][1], ...pixels[1][0]],
     ...[...pixels[0][1], ...pixels[0][0]],
@@ -59,9 +63,72 @@ test('vh flips images vertically and horizontally (gray)', () => {
     3
   )
 
-  expect([...vh(image).data]).toEqual([
+  vh(image)
+
+  expect([...image.data]).toEqual([
     ...[pixels[2][1], pixels[2][0]],
     ...[pixels[1][1], pixels[1][0]],
     ...[pixels[0][1], pixels[0][0]],
+  ])
+})
+
+test('flipping twice yields the same image (rgba)', () => {
+  const pixels = [
+    [
+      [0, 1, 2, 3],
+      [4, 5, 6, 7],
+    ],
+    [
+      [8, 9, 10, 11],
+      [12, 13, 14, 15],
+    ],
+    [
+      [16, 17, 18, 19],
+      [20, 21, 22, 23],
+    ],
+  ]
+  const image = createImageData(
+    Uint8ClampedArray.of(
+      ...[...pixels[0][0], ...pixels[0][1]],
+      ...[...pixels[1][0], ...pixels[1][1]],
+      ...[...pixels[2][0], ...pixels[2][1]]
+    ),
+    2,
+    3
+  )
+
+  vh(image)
+  vh(image)
+
+  expect([...image.data]).toEqual([
+    ...[...pixels[0][0], ...pixels[0][1]],
+    ...[...pixels[1][0], ...pixels[1][1]],
+    ...[...pixels[2][0], ...pixels[2][1]],
+  ])
+})
+
+test('flipping twice yields the same image (gray)', () => {
+  const pixels = [
+    [0, 1],
+    [2, 3],
+    [4, 5],
+  ]
+  const image = createImageData(
+    Uint8ClampedArray.of(
+      ...[pixels[0][0], pixels[0][1]],
+      ...[pixels[1][0], pixels[1][1]],
+      ...[pixels[2][0], pixels[2][1]]
+    ),
+    2,
+    3
+  )
+
+  vh(image)
+  vh(image)
+
+  expect([...image.data]).toEqual([
+    ...[pixels[0][0], pixels[0][1]],
+    ...[pixels[1][0], pixels[1][1]],
+    ...[pixels[2][0], pixels[2][1]],
   ])
 })

--- a/src/utils/flip.ts
+++ b/src/utils/flip.ts
@@ -1,46 +1,100 @@
-import { createImageData } from 'canvas'
-import { makeImageTransform } from './makeImageTransform'
+import {
+  assertGrayscaleImage,
+  assertImageSizesMatch,
+  assertRGBAImage,
+  makeInPlaceImageTransform,
+} from './makeImageTransform'
 
 /**
  * Flips an image vertically and horizontally, equivalent to a 180° rotation.
  */
-export const vh = makeImageTransform(vhGray, vhRGBA)
+export const vh = makeInPlaceImageTransform(vhGray, vhRGBA)
 
-export function vhRGBA({ data: src, width, height }: ImageData): ImageData {
-  const dst = new Uint8ClampedArray(src.length)
-  const result = createImageData(dst, width, height)
+export function vhRGBA(
+  srcImageData: ImageData,
+  dstImageData = srcImageData
+): void {
+  assertRGBAImage(srcImageData)
+  assertRGBAImage(dstImageData)
+  assertImageSizesMatch(srcImageData, dstImageData)
 
-  for (let y = 0; y < height; y += 1) {
-    const dstY = height - y - 1
+  const { data: src } = srcImageData
+  const { data: dst } = dstImageData
+  const size = src.length
 
-    for (let x = 0; x < width; x += 1) {
-      const dstX = width - x - 1
-      const srcOffset = (x + y * width) << 2
-      const dstOffset = (dstX + dstY * width) << 2
+  if (src === dst) {
+    // In-place flip means we need to be careful not to overwrite data before
+    // reading it. We can do that by working from the ends toward the middle and
+    // swapping the pixels as we find them.
+    const data = src
 
+    for (let left = 0, right = size - 4; left < right; left += 4, right -= 4) {
+      ;[
+        data[left],
+        data[left + 1],
+        data[left + 2],
+        data[left + 3],
+        data[right],
+        data[right + 1],
+        data[right + 2],
+        data[right + 3],
+      ] = [
+        data[right],
+        data[right + 1],
+        data[right + 2],
+        data[right + 3],
+        data[left],
+        data[left + 1],
+        data[left + 2],
+        data[left + 3],
+      ]
+    }
+  } else {
+    // Flipping from one image to another, we read `src` in reverse and put it
+    // one pixel at a time into `dst`.
+    for (
+      let dstOffset = 0, srcOffset = size - 4;
+      dstOffset < size;
+      dstOffset += 4, srcOffset -= 4
+    ) {
       dst[dstOffset] = src[srcOffset]
       dst[dstOffset + 1] = src[srcOffset + 1]
       dst[dstOffset + 2] = src[srcOffset + 2]
       dst[dstOffset + 3] = src[srcOffset + 3]
     }
   }
-
-  return result
 }
 
-export function vhGray({ data: src, width, height }: ImageData): ImageData {
-  const dst = new Uint8ClampedArray(src.length)
-  const result = createImageData(dst, width, height)
+export function vhGray(
+  srcImageData: ImageData,
+  dstImageData = srcImageData
+): void {
+  assertGrayscaleImage(srcImageData)
+  assertGrayscaleImage(dstImageData)
+  assertImageSizesMatch(srcImageData, dstImageData)
 
-  for (let y = 0; y < height; y += 1) {
-    const dstY = height - y - 1
+  const { data: src } = srcImageData
+  const { data: dst } = dstImageData
+  const size = src.length
 
-    for (let x = 0; x < width; x += 1) {
-      const dstX = width - x - 1
+  if (src === dst) {
+    // In-place flip means we need to be careful not to overwrite data before
+    // reading it. We can do that by working from the ends toward the middle and
+    // swapping the pixels as we find them.
+    const data = src
 
-      dst[dstX + dstY * width] = src[x + y * width]
+    for (let left = 0, right = size - 1; left < right; left += 1, right -= 1) {
+      ;[data[left], data[right]] = [data[right], data[left]]
+    }
+  } else {
+    // Flipping from one image to another, we read `src` in reverse and put it
+    // one pixel at a time into `dst`.
+    for (
+      let dstOffset = 0, srcOffset = size - 1;
+      dstOffset < size;
+      dstOffset += 1, srcOffset -= 1
+    ) {
+      dst[dstOffset] = src[srcOffset]
     }
   }
-
-  return result
 }


### PR DESCRIPTION
This should be more performant as it doesn't need to allocate a whole new image, which for a typical scanned ballot is 33MB.