### PR TITLE
fix(quirc): handle QR code errors better

### DIFF
--- a/src/utils/qrcode/quirc.ts
+++ b/src/utils/qrcode/quirc.ts
@@ -33,11 +33,11 @@ export async function detect(
   // handle raw bitmaps.
   const result = await quirc.decode(toPNGData(imageData))
 
-  if (result.length !== 1) {
-    return
+  for (const symbol of result) {
+    if (!('err' in symbol)) {
+      return { data: symbol.data }
+    }
   }
-
-  return { data: result[0].data }
 }
 
 export default withCropping(detect)

--- a/types/node-quirc.d.ts
+++ b/types/node-quirc.d.ts
@@ -1,3 +1,4 @@
+// TODO: delete this if/when https://github.com/kAworu/node-quirc/pull/11 is merged.
 declare module 'node-quirc' {
   export const constants: {
     // QR-code versions.
@@ -13,11 +14,26 @@ declare module 'node-quirc' {
     MODE_ALNUM: 'ALNUM'
     MODE_BYTE: 'BYTE'
     MODE_KANJI: 'KANJI'
+    // Common character encodings
+    ECI_ISO_8859_1: 'ISO_8859_1'
+    ECI_IBM437: 'IBM437'
+    ECI_ISO_8859_2: 'ISO_8859_2'
+    ECI_ISO_8859_3: 'ISO_8859_3'
+    ECI_ISO_8859_4: 'ISO_8859_4'
+    ECI_ISO_8859_5: 'ISO_8859_5'
+    ECI_ISO_8859_6: 'ISO_8859_6'
+    ECI_ISO_8859_7: 'ISO_8859_7'
+    ECI_ISO_8859_8: 'ISO_8859_8'
+    ECI_ISO_8859_9: 'ISO_8859_9'
+    ECI_WINDOWS_874: 'WINDOWS_874'
+    ECI_ISO_8859_13: 'ISO_8859_13'
+    ECI_ISO_8859_15: 'ISO_8859_15'
+    ECI_SHIFT_JIS: 'SHIFT_JIS'
+    ECI_UTF_8: 'UTF_8'
   }
 
-  interface QRCode {
+  export interface QRCode {
     version: number
-    // eslint-disable-next-line camelcase
     ecc_level:
       | typeof constants['ECC_LEVEL_M']
       | typeof constants['ECC_LEVEL_L']
@@ -32,11 +48,15 @@ declare module 'node-quirc' {
     data: Buffer
   }
 
-  // eslint-disable-next-line import/export
-  export function decode(img: Buffer): Promise<QRCode[]>
-  // eslint-disable-next-line import/export
+  export interface InvalidQRCode {
+    err: string
+  }
+
+  export type DecodeResult = (QRCode | InvalidQRCode)[]
+
+  export function decode(img: Buffer): Promise<DecodeResult>
   export function decode(
     img: Buffer,
-    callback: (err: Error, results: QRCode[]) => void
-  ): Promise<QRCode[]>
+    callback: (err: Error, results: DecodeResult) => void
+  ): void
 }


### PR DESCRIPTION
node-quirc will actually resolve the promise even if it finds a QR code it can't decode. This makes sense since there may be QR codes it could decode and you need a way to communicate that. The ones that error will have just an `err` property and nothing else, so we now just return the first QR code that does not have an `err` property.