### PR TITLE
refactor: simplify `crop`

### DIFF
--- a/src/utils/crop.test.ts
+++ b/src/utils/crop.test.ts
@@ -1,4 +1,40 @@
+import { createImageData } from 'canvas'
+import { randomImage, randomInset } from '../../test/utils'
+import { Rect } from '../types'
 import crop from './crop'
+
+/**
+ * A slow-but-accurate implementation of `crop` to compare against.
+ */
+function cropReferenceImplementation(
+  { data: src, width: srcWidth, height: srcHeight }: ImageData,
+  bounds: Rect
+): ImageData {
+  const channels = src.length / (srcWidth * srcHeight)
+  const dst = new Uint8ClampedArray(bounds.width * bounds.height * channels)
+  const {
+    x: srcXOffset,
+    y: srcYOffset,
+    width: dstWidth,
+    height: dstHeight,
+  } = bounds
+
+  for (let y = 0; y < dstHeight; y += 1) {
+    const srcY = srcYOffset + y
+
+    for (let x = 0; x < dstWidth; x += 1) {
+      const srcX = srcXOffset + x
+      const srcOffset = (srcX + srcY * srcWidth) * channels
+      const dstOffset = (x + y * dstWidth) * channels
+
+      for (let c = 0; c < channels; c += 1) {
+        dst[dstOffset + c] = src[srcOffset + c]
+      }
+    }
+  }
+
+  return createImageData(dst, dstWidth, dstHeight)
+}
 
 test('crop center (gray)', () => {
   const imageData = {
@@ -7,9 +43,14 @@ test('crop center (gray)', () => {
     height: 3,
   }
 
-  const { data, ...size } = crop(imageData, { x: 1, y: 1, width: 1, height: 1 })
+  const { data, width, height } = crop(imageData, {
+    x: 1,
+    y: 1,
+    width: 1,
+    height: 1,
+  })
   expect([...data]).toEqual([1])
-  expect(size).toEqual({ width: 1, height: 1 })
+  expect({ width, height }).toEqual({ width: 1, height: 1 })
 })
 
 test('crop center (rgba)', () => {
@@ -27,4 +68,42 @@ test('crop center (rgba)', () => {
   })
   expect([...data]).toEqual([1, 0, 0, 255])
   expect({ width, height }).toEqual({ width: 1, height: 1 })
+})
+
+test('crop random (gray)', () => {
+  const imageData = randomImage({ channels: 1, maxWidth: 20, maxHeight: 20 })
+  const cropBounds = randomInset({
+    x: 0,
+    y: 0,
+    width: imageData.width,
+    height: imageData.height,
+  })
+
+  const actual = crop(imageData, cropBounds)
+  const expected = cropReferenceImplementation(imageData, cropBounds)
+
+  expect({ width: actual.width, height: actual.height }).toEqual({
+    width: expected.width,
+    height: expected.height,
+  })
+  expect([...actual.data]).toEqual([...expected.data])
+})
+
+test('crop random (rgba)', () => {
+  const imageData = randomImage({ channels: 4, maxWidth: 20, maxHeight: 20 })
+  const cropBounds = randomInset({
+    x: 0,
+    y: 0,
+    width: imageData.width,
+    height: imageData.height,
+  })
+
+  const actual = crop(imageData, cropBounds)
+  const expected = cropReferenceImplementation(imageData, cropBounds)
+
+  expect({ width: actual.width, height: actual.height }).toEqual({
+    width: expected.width,
+    height: expected.height,
+  })
+  expect([...actual.data]).toEqual([...expected.data])
 })

--- a/src/utils/crop.ts
+++ b/src/utils/crop.ts
@@ -1,20 +1,15 @@
 import { createImageData } from 'canvas'
 import { Rect } from '../types'
-import { makeImageTransform } from './makeImageTransform'
 
 /**
  * Returns a new image cropped to the specified bounds.
  */
-export default makeImageTransform(gray, rgba)
-
-/**
- * Returns a new grayscale image cropped to the specified bounds.
- */
-export function gray(
-  { data: src, width: srcWidth }: ImageData,
+export default function crop(
+  { data: src, width: srcWidth, height: srcHeight }: ImageData,
   bounds: Rect
 ): ImageData {
-  const dst = new Uint8ClampedArray(bounds.width * bounds.height)
+  const channels = src.length / (srcWidth * srcHeight)
+  const dst = new Uint8ClampedArray(bounds.width * bounds.height * channels)
   const {
     x: srcXOffset,
     y: srcYOffset,
@@ -23,48 +18,12 @@ export function gray(
   } = bounds
 
   for (let y = 0; y < dstHeight; y += 1) {
-    const srcY = srcYOffset + y
-
-    for (let x = 0; x < dstWidth; x += 1) {
-      const srcX = srcXOffset + x
-      const srcOffset = srcX + srcY * srcWidth
-      const dstOffset = x + y * dstWidth
-
-      dst[dstOffset] = src[srcOffset]
-    }
-  }
-
-  return { data: dst, width: dstWidth, height: dstHeight }
-}
-
-/**
- * Returns a new RGBA image cropped to the specified bounds.
- */
-export function rgba(
-  { data: src, width: srcWidth }: ImageData,
-  bounds: Rect
-): ImageData {
-  const dst = new Uint8ClampedArray(bounds.width * bounds.height * 4)
-  const {
-    x: srcXOffset,
-    y: srcYOffset,
-    width: dstWidth,
-    height: dstHeight,
-  } = bounds
-
-  for (let y = 0; y < dstHeight; y += 1) {
-    const srcY = srcYOffset + y
-
-    for (let x = 0; x < dstWidth; x += 1) {
-      const srcX = srcXOffset + x
-      const srcOffset = (srcX + srcY * srcWidth) << 2
-      const dstOffset = (x + y * dstWidth) << 2
-
-      dst[dstOffset] = src[srcOffset]
-      dst[dstOffset + 1] = src[srcOffset + 1]
-      dst[dstOffset + 2] = src[srcOffset + 2]
-      dst[dstOffset + 3] = src[srcOffset + 3]
-    }
+    const srcOffset = (srcYOffset + y) * srcWidth + srcXOffset
+    const dstOffset = y * dstWidth
+    dst.set(
+      src.subarray(srcOffset * channels, (srcOffset + dstWidth) * channels),
+      dstOffset * channels
+    )
   }
 
   return createImageData(dst, dstWidth, dstHeight)

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,7 +1,52 @@
-import { createCanvas } from 'canvas'
+import { createCanvas, createImageData } from 'canvas'
 import { promises as fs } from 'fs'
 import { Rect } from '../src/types'
 import { toRGBA } from '../src/utils/convert'
+import { randomBytes } from 'crypto'
+
+export function randomImage({
+  width = 0,
+  height = 0,
+  minWidth = 1,
+  maxWidth = 10,
+  minHeight = 1,
+  maxHeight = 10,
+  channels = 4,
+} = {}): ImageData {
+  if (!width) {
+    width = (minWidth + Math.random() * (maxWidth - minWidth + 1)) | 0
+  }
+  if (!height) {
+    height = (minHeight + Math.random() * (maxHeight - minHeight + 1)) | 0
+  }
+  const data = new Uint8ClampedArray(randomBytes(width * height * channels))
+  return createImageData(data, width, height)
+}
+
+export function randomInset(
+  rect: Rect,
+  { min = 0, max = Math.min(rect.width, rect.height) } = {}
+): Rect {
+  const leftInset =
+    Math.max(min, Math.min(max, rect.width / 2 - 1, randomInt(min, max))) | 0
+  const rightInset =
+    Math.max(min, Math.min(max, rect.width / 2 - 1, randomInt(min, max))) | 0
+  const topInset =
+    Math.max(min, Math.min(max, rect.height / 2 - 1, randomInt(min, max))) | 0
+  const bottomInset =
+    Math.max(min, Math.min(max, rect.width / 2 - 1, randomInt(min, max))) | 0
+
+  return {
+    x: rect.x + leftInset,
+    y: rect.y + topInset,
+    width: rect.width - leftInset - rightInset,
+    height: rect.height - topInset - bottomInset,
+  }
+}
+
+export function randomInt(min: number, max: number): number {
+  return (min + Math.random() * (max - min + 1)) | 0
+}
 
 export async function writeImageToFile(
   imageData: ImageData,


### PR DESCRIPTION
This uses a technique pointed out here: https://github.com/cozmo/jsQR/issues/168#issuecomment-621520019. It should be more efficient, and has the added bonus of working with both RGBA and grayscale.