### PR TITLE
fix: ensure rect corners are in bounds

### DIFF
--- a/src/Interpreter.test.ts
+++ b/src/Interpreter.test.ts
@@ -572,7 +572,7 @@ test('interpret multiple vote', async () => {
       },
       Object {
         "option": "Eddie Bernice Johnson",
-        "score": 0.3813215208564046,
+        "score": 0.38095238095238093,
         "type": "candidate",
       },
       Object {

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,8 @@ export interface Rect {
   height: number
 }
 
+export type Corners = [Point, Point, Point, Point]
+
 export interface Size {
   width: number
   height: number

--- a/src/utils/geometry.test.ts
+++ b/src/utils/geometry.test.ts
@@ -1,4 +1,31 @@
-import { flipRectVH } from './geometry'
+import { flipRectVH, rectCorners } from './geometry'
+import { randomInt } from '../../test/utils'
+
+test('rectCorners of 1x1 rect', () => {
+  const corners = rectCorners({
+    x: randomInt(),
+    y: randomInt(),
+    width: 1,
+    height: 1,
+  })
+  expect(corners[0]).toEqual(corners[1])
+  expect(corners[0]).toEqual(corners[2])
+  expect(corners[0]).toEqual(corners[3])
+})
+
+test('rectCorners', () => {
+  const x = randomInt(-1000, 1000)
+  const y = randomInt(-1000, 1000)
+  const width = randomInt(1, 1000)
+  const height = randomInt(1, 1000)
+  const corners = rectCorners({ x, y, width, height })
+  expect(corners).toEqual([
+    { x, y },
+    { x: x + width - 1, y },
+    { x, y: y + height - 1 },
+    { x: x + width - 1, y: y + height - 1 },
+  ])
+})
 
 test('flipRectVH anchored top-left', () => {
   expect(

--- a/src/utils/geometry.ts
+++ b/src/utils/geometry.ts
@@ -1,11 +1,14 @@
-import { Point, Rect } from '../types'
+import { Corners, Rect } from '../types'
 
-export function rectCorners({ x, y, width, height }: Rect): Point[] {
+/**
+ * Gets the four extreme points of a rectangle, inclusive.
+ */
+export function rectCorners({ x, y, width, height }: Rect): Corners {
   return [
     { x, y },
-    { x: x + width, y },
-    { x, y: y + height },
-    { x: x + width, y: y + height },
+    { x: x + width - 1, y },
+    { x, y: y + height - 1 },
+    { x: x + width - 1, y: y + height - 1 },
   ]
 }
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,8 +1,9 @@
+import { strict as assert } from 'assert'
 import { createCanvas, createImageData } from 'canvas'
+import { randomBytes } from 'crypto'
 import { promises as fs } from 'fs'
 import { Rect } from '../src/types'
 import { toRGBA } from '../src/utils/convert'
-import { randomBytes } from 'crypto'
 
 export function randomImage({
   width = 0,
@@ -14,11 +15,23 @@ export function randomImage({
   channels = 4,
 } = {}): ImageData {
   if (!width) {
-    width = (minWidth + Math.random() * (maxWidth - minWidth + 1)) | 0
+    assert(minWidth <= maxWidth)
+
+    width = Math.max(
+      1,
+      (minWidth + Math.random() * (maxWidth - minWidth + 1)) | 0
+    )
   }
   if (!height) {
-    height = (minHeight + Math.random() * (maxHeight - minHeight + 1)) | 0
+    assert(minHeight <= maxHeight)
+
+    height = Math.max(
+      1,
+      (minHeight + Math.random() * (maxHeight - minHeight + 1)) | 0
+    )
   }
+  assert(width >= 0)
+  assert(height >= 0)
   const data = new Uint8ClampedArray(randomBytes(width * height * channels))
   return createImageData(data, width, height)
 }
@@ -27,6 +40,9 @@ export function randomInset(
   rect: Rect,
   { min = 0, max = Math.min(rect.width, rect.height) } = {}
 ): Rect {
+  assert(min >= 0)
+  assert(max >= min)
+
   const leftInset =
     Math.max(min, Math.min(max, rect.width / 2 - 1, randomInt(min, max))) | 0
   const rightInset =
@@ -34,7 +50,10 @@ export function randomInset(
   const topInset =
     Math.max(min, Math.min(max, rect.height / 2 - 1, randomInt(min, max))) | 0
   const bottomInset =
-    Math.max(min, Math.min(max, rect.width / 2 - 1, randomInt(min, max))) | 0
+    Math.max(min, Math.min(max, rect.height / 2 - 1, randomInt(min, max))) | 0
+
+  assert(rect.width - leftInset - rightInset > 0)
+  assert(rect.height - topInset - bottomInset > 0)
 
   return {
     x: rect.x + leftInset,
@@ -44,7 +63,11 @@ export function randomInset(
   }
 }
 
-export function randomInt(min: number, max: number): number {
+export function randomInt(
+  min = Number.MIN_SAFE_INTEGER,
+  max = Number.MAX_SAFE_INTEGER
+): number {
+  assert(min <= max)
   return (min + Math.random() * (max - min + 1)) | 0
 }
 


### PR DESCRIPTION
This was a classic off-by-one error. Also adds some assertions to validate the test data.