### PR TITLE
fix: support diffing images of different widths

### DIFF
--- a/src/Interpreter.ts
+++ b/src/Interpreter.ts
@@ -31,7 +31,7 @@ import defined from './utils/defined'
 import { vh as flipVH } from './utils/flip'
 import { rectCorners } from './utils/geometry'
 import { map, reversed, zip, zipMin } from './utils/iterators'
-import { ratio } from './utils/jsfeat/diff'
+import diff, { ratio } from './utils/jsfeat/diff'
 import matToImageData from './utils/jsfeat/matToImageData'
 import readGrayscaleImage from './utils/jsfeat/readGrayscaleImage'
 
@@ -439,7 +439,7 @@ export default class Interpreter {
     ballot: ImageData,
     target: Rect
   ): number {
-    return ratio(template, ballot, target, target)
+    return ratio(diff(template, ballot, target, target))
   }
 
   private mapBallotOntoTemplate(

--- a/src/utils/flip.ts
+++ b/src/utils/flip.ts
@@ -1,7 +1,7 @@
 import {
   assertGrayscaleImage,
-  assertImageSizesMatch,
   assertRGBAImage,
+  assertSizesMatch,
   makeInPlaceImageTransform,
 } from './makeImageTransform'
 
@@ -16,7 +16,7 @@ export function vhRGBA(
 ): void {
   assertRGBAImage(srcImageData)
   assertRGBAImage(dstImageData)
-  assertImageSizesMatch(srcImageData, dstImageData)
+  assertSizesMatch(srcImageData, dstImageData)
 
   const { data: src } = srcImageData
   const { data: dst } = dstImageData
@@ -71,7 +71,7 @@ export function vhGray(
 ): void {
   assertGrayscaleImage(srcImageData)
   assertGrayscaleImage(dstImageData)
-  assertImageSizesMatch(srcImageData, dstImageData)
+  assertSizesMatch(srcImageData, dstImageData)
 
   const { data: src } = srcImageData
   const { data: dst } = dstImageData

--- a/src/utils/grayscale.ts
+++ b/src/utils/grayscale.ts
@@ -1,9 +1,9 @@
 import {
   assertGrayscaleImage,
-  assertImageSizesMatch,
   assertRGBAImage,
-  makeInPlaceImageTransform,
+  assertSizesMatch,
   isRGBA,
+  makeInPlaceImageTransform,
 } from './makeImageTransform'
 
 export default makeInPlaceImageTransform(fromGray, fromRGBA)
@@ -17,7 +17,7 @@ export function fromGray(
 ): void {
   assertGrayscaleImage(srcImageData)
   assertGrayscaleImage(dstImageData)
-  assertImageSizesMatch(srcImageData, dstImageData)
+  assertSizesMatch(srcImageData, dstImageData)
 
   if (srcImageData === dstImageData) {
     return
@@ -37,7 +37,7 @@ export function fromRGBA(
   dstImageData = srcImageData
 ): void {
   assertRGBAImage(srcImageData)
-  assertImageSizesMatch(srcImageData, dstImageData)
+  assertSizesMatch(srcImageData, dstImageData)
 
   const { data: src, width, height } = srcImageData
   const { data: dst } = dstImageData

--- a/src/utils/jsfeat/diff.test.ts
+++ b/src/utils/jsfeat/diff.test.ts
@@ -1,5 +1,7 @@
-import diff, { ratio } from './diff'
+import { croppedQRCode } from '../../../test/fixtures'
 import { PIXEL_BLACK, PIXEL_WHITE } from '../binarize'
+import crop from '../crop'
+import diff, { ratio } from './diff'
 
 test('images have no diff with themselves', () => {
   const imageData = {
@@ -70,7 +72,7 @@ test('images have no percentage diff with themselves', () => {
     height: 1,
   }
 
-  expect(ratio(imageData, imageData)).toEqual(0)
+  expect(ratio(diff(imageData, imageData))).toEqual(0)
 })
 
 test('images have diff percentage as ratio of black diff pixels to total pixels', () => {
@@ -85,5 +87,18 @@ test('images have diff percentage as ratio of black diff pixels to total pixels'
     height: 1,
   }
 
-  expect(ratio(base, compare)).toEqual(0.5)
+  expect(ratio(diff(base, compare))).toEqual(0.5)
+})
+
+test('comparing part of an image to all of another', async () => {
+  const base = await croppedQRCode.imageData()
+  const compareBounds = { x: 150, y: 80, width: 150, height: 80 }
+  const compare = crop(base, compareBounds)
+  const diffImage = diff(base, compare, compareBounds, {
+    ...compareBounds,
+    x: 0,
+    y: 0,
+  })
+
+  expect(ratio(diffImage)).toBe(0)
 })

--- a/src/utils/makeImageTransform.ts
+++ b/src/utils/makeImageTransform.ts
@@ -1,4 +1,5 @@
 import { strict as assert } from 'assert'
+import { Size } from '../types'
 
 export type InPlaceImageTransform<A extends unknown[], R> = (
   srcImageData: ImageData,
@@ -86,14 +87,11 @@ export function assertImageChannelsMatch(
   )
 }
 
-export function assertImageSizesMatch(
-  imageData1: ImageData,
-  imageData2: ImageData
-): void {
+export function assertSizesMatch(size1: Size, size2: Size): void {
   assert.deepEqual(
-    { width: imageData1.width, height: imageData1.height },
-    { width: imageData2.width, height: imageData2.height },
-    'expected source and destination image sizes to be equal'
+    { width: size1.width, height: size1.height },
+    { width: size2.width, height: size2.height },
+    'expected sizes to be equal'
   )
 }
 


### PR DESCRIPTION
The comparison bounds still need to be equally-sized, but it previously assumed that the `base` and `compare` images were themselves the same sizes.