### PR TITLE
fix: ensure "no" target options are recorded as such

### DIFF
--- a/src/Interpreter.test.ts
+++ b/src/Interpreter.test.ts
@@ -1062,7 +1062,7 @@ test('invalid marks', async () => {
           "title": "Retain Robert Demergue as Chief Justice?",
           "type": "yesno",
         },
-        "option": "yes",
+        "option": "no",
         "score": 0,
         "target": Object {
           "bounds": Object {
@@ -1128,7 +1128,7 @@ test('invalid marks', async () => {
           "title": "Proposition R: Countywide Recycling Program",
           "type": "yesno",
         },
-        "option": "yes",
+        "option": "no",
         "score": 0,
         "target": Object {
           "bounds": Object {

--- a/src/Interpreter.ts
+++ b/src/Interpreter.ts
@@ -494,7 +494,7 @@ export default class Interpreter {
           type: 'yesno',
           bounds: noOption.target.bounds,
           contest,
-          option: 'yes',
+          option: 'no',
           score: noScore,
           target: noOption.target,
         }


### PR DESCRIPTION
Before this fix, any "no" votes would be counted as "yes" votes.