### PR TITLE
feat: allow specifying whether a ballot is flipped

### DIFF
--- a/src/Interpreter.test.ts
+++ b/src/Interpreter.test.ts
@@ -7,7 +7,6 @@ import {
 import election from '../test/fixtures/election-4e31cb17d8f2f3bac574c6d2f6e22fb2528dcdf8-ballot-style-77-precinct-oaklawn-branch-library/election'
 import Interpreter from './Interpreter'
 import { DetectQRCodeResult } from './types'
-import { vh as flipVH } from './utils/flip'
 
 test('interpret two-column template', async () => {
   const interpreter = new Interpreter(election)
@@ -2043,10 +2042,9 @@ test('upside-down ballot', async () => {
     await blankPage2.metadata()
   )
 
-  const imageData = await filledInPage1.imageData()
-  flipVH(imageData)
-
-  const { ballot } = await interpreter.interpretBallot(imageData)
+  const { ballot, metadata } = await interpreter.interpretBallot(
+    await filledInPage1.imageData()
+  )
   expect(ballot.votes).toMatchInlineSnapshot(`
     Object {
       "dallas-county-sheriff": Array [
@@ -2096,4 +2094,14 @@ test('upside-down ballot', async () => {
       ],
     }
   `)
+
+  const {
+    ballot: { votes: votesWithFlipped },
+  } = await interpreter.interpretBallot(
+    await filledInPage1.imageData({ flipped: true }),
+    metadata,
+    { flipped: true }
+  )
+
+  expect(votesWithFlipped).toEqual(ballot.votes)
 })

--- a/src/metadata.test.ts
+++ b/src/metadata.test.ts
@@ -1,7 +1,6 @@
 import { croppedQRCode } from '../test/fixtures'
 import { blankPage1 } from '../test/fixtures/election-4e31cb17d8f2f3bac574c6d2f6e22fb2528dcdf8-ballot-style-77-precinct-oaklawn-branch-library'
 import { decodeSearchParams, detect } from './metadata'
-import { vh as flipVH } from './utils/flip'
 import { jsqr } from './utils/qrcode'
 
 test('URL decoding', () => {
@@ -90,11 +89,7 @@ test('custom QR code reader', async () => {
 })
 
 test('upside-down ballot images', async () => {
-  const imageData = await blankPage1.imageData()
-
-  flipVH(imageData)
-
-  expect(await detect(imageData)).toEqual({
+  expect(await detect(await blankPage1.imageData({ flipped: true }))).toEqual({
     metadata: {
       ballotStyleId: '77',
       precinctId: '42',

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'fs'
 import { basename, dirname, extname, join } from 'path'
 import { BallotPageMetadata, Input } from '../src'
+import { vh as flipVH } from '../src/utils/flip'
 import { readImageData } from '../src/utils/readImageData'
 
 export class Fixture implements Input {
@@ -14,8 +15,12 @@ export class Fixture implements Input {
     return this.basePath
   }
 
-  public async imageData(): Promise<ImageData> {
-    return await readImageData(this.filePath())
+  public async imageData({ flipped = false } = {}): Promise<ImageData> {
+    const imageData = await readImageData(this.filePath())
+    if (flipped) {
+      flipVH(imageData)
+    }
+    return imageData
   }
 
   public async metadata(): Promise<BallotPageMetadata> {


### PR DESCRIPTION
This could be used by `module-scan` to look for QR codes ahead of time and provide the metadata and orientation information instead of making this library do it.