### PR TITLE
style: organize imports across all files

### DIFF
--- a/src/Interpreter.test.ts
+++ b/src/Interpreter.test.ts
@@ -1,13 +1,13 @@
-import Interpreter from './Interpreter'
-import { DetectQRCodeResult } from './types'
-import { vh as flipVH } from './utils/flip'
-import election from '../test/fixtures/election-4e31cb17d8f2f3bac574c6d2f6e22fb2528dcdf8-ballot-style-77-precinct-oaklawn-branch-library/election'
 import {
   blankPage1,
   blankPage2,
   filledInPage1,
   filledInPage2,
 } from '../test/fixtures/election-4e31cb17d8f2f3bac574c6d2f6e22fb2528dcdf8-ballot-style-77-precinct-oaklawn-branch-library'
+import election from '../test/fixtures/election-4e31cb17d8f2f3bac574c6d2f6e22fb2528dcdf8-ballot-style-77-precinct-oaklawn-branch-library/election'
+import Interpreter from './Interpreter'
+import { DetectQRCodeResult } from './types'
+import { vh as flipVH } from './utils/flip'
 
 test('interpret two-column template', async () => {
   const interpreter = new Interpreter(election)

--- a/src/cli/commands/interpret.ts
+++ b/src/cli/commands/interpret.ts
@@ -1,16 +1,12 @@
-import {
-  Election,
-  Candidate,
-  CompletedBallot,
-} from '@votingworks/ballot-encoder'
-import { promises as fs } from 'fs'
-import { OptionParseError } from '..'
-import { Input, Interpreted } from '../../types'
-import { Interpreter } from '../..'
-import { table } from 'table'
+import { Candidate, Election } from '@votingworks/ballot-encoder'
 import chalk from 'chalk'
-import { readImageData } from '../../utils/readImageData'
+import { promises as fs } from 'fs'
+import { table } from 'table'
+import { OptionParseError } from '..'
+import { Interpreter } from '../..'
 import { DEFAULT_MARK_SCORE_VOTE_THRESHOLD } from '../../Interpreter'
+import { Input, Interpreted } from '../../types'
+import { readImageData } from '../../utils/readImageData'
 
 export enum OutputFormat {
   JSON = 'json',

--- a/src/hmpb/scanColumns.ts
+++ b/src/hmpb/scanColumns.ts
@@ -1,4 +1,4 @@
-import { Rect, Point } from '../types'
+import { Point, Rect } from '../types'
 
 export interface Options {
   readonly columns: readonly boolean[]

--- a/src/hmpb/votes.ts
+++ b/src/hmpb/votes.ts
@@ -1,8 +1,8 @@
 import {
-  CandidateContest,
   Candidate,
-  YesNoContest,
+  CandidateContest,
   VotesDict,
+  YesNoContest,
 } from '@votingworks/ballot-encoder'
 import { inspect } from 'util'
 

--- a/src/utils/jsfeat/drawToCanvas.ts
+++ b/src/utils/jsfeat/drawToCanvas.ts
@@ -1,5 +1,5 @@
-import * as jsfeat from 'jsfeat'
 import { Canvas } from 'canvas'
+import * as jsfeat from 'jsfeat'
 
 export default function drawToCanvas(
   canvas: Canvas,

--- a/src/utils/qrcode/index.ts
+++ b/src/utils/qrcode/index.ts
@@ -1,6 +1,6 @@
+import { DetectQRCodeResult } from '../../types'
 import jsqr from './jsqr'
 import quirc from './quirc'
-import { DetectQRCodeResult } from '../../types'
 
 export { jsqr, quirc }
 

--- a/src/utils/qrcode/quirc.ts
+++ b/src/utils/qrcode/quirc.ts
@@ -1,7 +1,7 @@
 import { createCanvas } from 'canvas'
 import * as quirc from 'node-quirc'
-import { withCropping } from './withCropping'
 import { DetectQRCodeResult } from '../../types'
+import { withCropping } from './withCropping'
 
 const PNG_DATA_URL_PREFIX = 'data:image/png;base64,'
 

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -1,5 +1,5 @@
 import { promises as fs } from 'fs'
-import { join, dirname, basename, extname } from 'path'
+import { basename, dirname, extname, join } from 'path'
 import { BallotPageMetadata, Input } from '../src'
 import { readImageData } from '../src/utils/readImageData'
 


### PR DESCRIPTION
Removes an unused import in `interpret.ts`.