### PR TITLE
fix: enforce test mode for scanned ballots

### DIFF
--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -23,14 +23,19 @@ export class Fixture implements Input {
     return imageData
   }
 
-  public async metadata(): Promise<BallotPageMetadata> {
+  public async metadata(
+    overrides: Partial<BallotPageMetadata> = {}
+  ): Promise<BallotPageMetadata> {
     const imagePath = this.filePath()
     const ext = extname(imagePath)
     const metadataPath = `${join(
       dirname(imagePath),
       basename(imagePath, ext)
     )}-metadata.json`
-    return JSON.parse(await fs.readFile(metadataPath, 'utf8'))
+    return {
+      ...JSON.parse(await fs.readFile(metadataPath, 'utf8')),
+      ...overrides,
+    }
   }
 }
 

--- a/test/fixtures/election-4e31cb17d8f2f3bac574c6d2f6e22fb2528dcdf8-ballot-style-77-precinct-oaklawn-branch-library/blank-p1-metadata.json
+++ b/test/fixtures/election-4e31cb17d8f2f3bac574c6d2f6e22fb2528dcdf8-ballot-style-77-precinct-oaklawn-branch-library/blank-p1-metadata.json
@@ -1,6 +1,6 @@
 {
   "ballotStyleId": "77",
-  "isTestBallot": true,
+  "isTestBallot": false,
   "pageCount": 2,
   "pageNumber": 1,
   "precinctId": "42"

--- a/test/fixtures/election-4e31cb17d8f2f3bac574c6d2f6e22fb2528dcdf8-ballot-style-77-precinct-oaklawn-branch-library/blank-p2-metadata.json
+++ b/test/fixtures/election-4e31cb17d8f2f3bac574c6d2f6e22fb2528dcdf8-ballot-style-77-precinct-oaklawn-branch-library/blank-p2-metadata.json
@@ -1,6 +1,6 @@
 {
   "ballotStyleId": "77",
-  "isTestBallot": true,
+  "isTestBallot": false,
   "pageCount": 2,
   "pageNumber": 2,
   "precinctId": "42"

--- a/test/fixtures/election-4e31cb17d8f2f3bac574c6d2f6e22fb2528dcdf8-ballot-style-77-precinct-oaklawn-branch-library/filled-in-p1-metadata.json
+++ b/test/fixtures/election-4e31cb17d8f2f3bac574c6d2f6e22fb2528dcdf8-ballot-style-77-precinct-oaklawn-branch-library/filled-in-p1-metadata.json
@@ -1,6 +1,6 @@
 {
   "ballotStyleId": "77",
-  "isTestBallot": true,
+  "isTestBallot": false,
   "pageCount": 2,
   "pageNumber": 1,
   "precinctId": "42"

--- a/test/fixtures/election-4e31cb17d8f2f3bac574c6d2f6e22fb2528dcdf8-ballot-style-77-precinct-oaklawn-branch-library/filled-in-p2-metadata.json
+++ b/test/fixtures/election-4e31cb17d8f2f3bac574c6d2f6e22fb2528dcdf8-ballot-style-77-precinct-oaklawn-branch-library/filled-in-p2-metadata.json
@@ -1,6 +1,6 @@
 {
   "ballotStyleId": "77",
-  "isTestBallot": true,
+  "isTestBallot": false,
   "pageCount": 2,
   "pageNumber": 2,
   "precinctId": "42"


### PR DESCRIPTION
This change requires that an interpreter have a test mode set, and that ballots and templates to be processed match that test mode.

votingworks/vxmail#32