### PR TITLE
feat: expose mapped ballot in interpreted result

### DIFF
--- a/src/Interpreter.test.ts
+++ b/src/Interpreter.test.ts
@@ -618,10 +618,13 @@ test('interpret empty ballot', async () => {
 
   const {
     matchedTemplate,
+    mappedBallot,
     metadata,
     ballot,
   } = await interpreter.interpretBallot(await blankPage1.imageData())
   expect(matchedTemplate === p1).toBe(true)
+  expect(mappedBallot.width).toBe(matchedTemplate.ballotImage.imageData.width)
+  expect(mappedBallot.height).toBe(matchedTemplate.ballotImage.imageData.height)
   expect(metadata.ballotStyleId).toEqual(p1.ballotImage.metadata.ballotStyleId)
   expect(ballot.votes).toEqual({})
 })

--- a/src/Interpreter.ts
+++ b/src/Interpreter.ts
@@ -346,13 +346,13 @@ export default class Interpreter {
     const matchedTemplate = defined(
       this.getTemplate(ballotStyleId, precinctId, pageNumber)
     )
-    const marks = this.getMarksForBallot(
+    const [mappedBallot, marks] = this.getMarksForBallot(
       ballotLayout,
       matchedTemplate,
       this.getContestsForTemplate(matchedTemplate)
     )
 
-    return { matchedTemplate, metadata, marks }
+    return { matchedTemplate, mappedBallot, metadata, marks }
   }
 
   /**
@@ -451,7 +451,7 @@ export default class Interpreter {
     ballotLayout: BallotPageLayout,
     template: BallotPageLayout,
     contests: Contests
-  ): BallotMark[] {
+  ): [ImageData, BallotMark[]] {
     assert.equal(
       template.contests.length,
       contests.length,
@@ -569,7 +569,7 @@ export default class Interpreter {
       }
     }
 
-    return marks
+    return [mappedBallot, marks]
   }
 
   private targetMarkScore(

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,6 +62,7 @@ export interface GetBallotOptions {
 
 export interface Interpreted {
   matchedTemplate: BallotPageLayout
+  mappedBallot: ImageData
   metadata: BallotPageMetadata
   marks: BallotMark[]
   ballot: CompletedBallot
@@ -69,6 +70,7 @@ export interface Interpreted {
 
 export interface FindMarksResult {
   matchedTemplate: BallotPageLayout
+  mappedBallot: ImageData
   metadata: BallotPageMetadata
   marks: BallotMark[]
 }


### PR DESCRIPTION
The marks in the output are in the coordinate space of the mapped ballot, so if we want to line them up with the image we need the mapped image.