### PR TITLE
fix: allow interpreting template even with a different test mode

### DIFF
--- a/src/Interpreter.test.ts
+++ b/src/Interpreter.test.ts
@@ -2115,7 +2115,7 @@ test('enforcing test vs live mode', async () => {
       await blankPage1.metadata({ isTestBallot: true })
     )
   ).rejects.toThrowError(
-    'interpreter configured with testMode=false cannot process ballots with isTestBallot=true'
+    'interpreter configured with testMode=false cannot add templates with isTestBallot=true'
   )
 
   await interpreter.addTemplate(
@@ -2133,8 +2133,21 @@ test('enforcing test vs live mode', async () => {
       await blankPage1.metadata({ isTestBallot: true })
     )
   ).rejects.toThrowError(
-    'interpreter configured with testMode=false cannot process ballots with isTestBallot=true'
+    'interpreter configured with testMode=false cannot interpret ballots with isTestBallot=true'
   )
+})
+
+test('can interpret a template that is not in the same mode as the interpreter', async () => {
+  const interpreter = new Interpreter({ election, testMode: true })
+
+  expect(
+    (
+      await interpreter.interpretTemplate(
+        await blankPage1.imageData(),
+        await blankPage1.metadata({ isTestBallot: false })
+      )
+    ).ballotImage.metadata.isTestBallot
+  ).toBe(false)
 })
 
 test('regression: page outline', async () => {


### PR DESCRIPTION
I plan to store the results of ballot interpretation in the database, and so I'll need to interpret live and test ballots using the same interpreter. I'll only add the ones that match the expected mode.