### PR TITLE
test: replace `vx.vote` with `ballot.page`

### DIFF
--- a/src/Interpreter.test.ts
+++ b/src/Interpreter.test.ts
@@ -2014,7 +2014,7 @@ test('custom QR code reader', async () => {
   const interpreter = new Interpreter({
     election,
     detectQRCode: async (): Promise<DetectQRCodeResult> => ({
-      data: Buffer.from('https://vx.vote?t=_&pr=11&bs=22&p=3-4'),
+      data: Buffer.from('https://ballot.page?t=_&pr=11&bs=22&p=3-4'),
     }),
   })
   const template = await interpreter.interpretTemplate(

--- a/src/metadata.test.ts
+++ b/src/metadata.test.ts
@@ -73,7 +73,7 @@ test('custom QR code reader', async () => {
   expect(
     await detect(await blankPage1.imageData(), {
       detectQRCode: async () => ({
-        data: Buffer.from('https://vx.vote?t=_&pr=11&bs=22&p=3-4'),
+        data: Buffer.from('https://ballot.page?t=_&pr=11&bs=22&p=3-4'),
       }),
     })
   ).toEqual({


### PR DESCRIPTION
The only changes needed are in the tests, since the scheme, path, and host of the QR code URL are ignored.