### PR TITLE
feat: allow passing metadata in JSON files for CLI processing

### DIFF
--- a/src/cli/commands/help.ts
+++ b/src/cli/commands/help.ts
@@ -29,13 +29,9 @@ export function printHelp(out: typeof process.stdout): void {
     `${$0} interpret -e election.json -f json template*.jpg ballot*.jpg\n`
   )
   out.write(`\n`)
+  out.write(chalk.gray(`# Specify image metadata (file:metdata-file).\n`))
   out.write(
-    chalk.gray(
-      `# Specify image metadata (file:ballotStyleId:precinctId:pageNumber:pageCount).\n`
-    )
-  )
-  out.write(
-    `${$0} interpret -e election.json template1.jpg:2D:77:1:2 template2.jpg:2D:77:2:2 ballot1.jpg:2D:77:1:2\n`
+    `${$0} interpret -e election.json template1.jpg:template1-metadata.json template2.jpg:template2-metdata.json ballot1.jpg:ballot1-metadata.json\n`
   )
   out.write(`\n`)
   out.write(chalk.gray(`# Set an explicit minimum mark score (0-1).\n`))

--- a/src/cli/commands/interpret.ts
+++ b/src/cli/commands/interpret.ts
@@ -5,12 +5,7 @@ import { table } from 'table'
 import { OptionParseError } from '..'
 import { Interpreter } from '../..'
 import { DEFAULT_MARK_SCORE_VOTE_THRESHOLD } from '../../Interpreter'
-import {
-  BallotLocales,
-  BallotPageMetadata,
-  Input,
-  Interpreted,
-} from '../../types'
+import { Input, Interpreted } from '../../types'
 import { readImageData } from '../../utils/readImageData'
 
 export enum OutputFormat {
@@ -28,33 +23,14 @@ export interface Options {
 }
 
 function makeInputFromBallotArgument(arg: string): Input {
-  const args = arg.split(':')
-
-  if (args.length === 5) {
-    args.splice(1, 0, '')
-  }
-
-  const [
-    file,
-    locales,
-    ballotStyleId,
-    precinctId,
-    pageNumber,
-    pageCount,
-  ] = arg.split(':')
+  const [ballotFile, metadataFile] = arg.split(':')
   const input: Input = {
-    id: () => file,
-    imageData: () => readImageData(file),
-  }
-  if (ballotStyleId && precinctId && pageNumber && pageCount) {
-    input.metadata = async (): Promise<BallotPageMetadata> => ({
-      locales: (locales.split(',').filter(Boolean) as unknown) as BallotLocales,
-      ballotStyleId,
-      precinctId,
-      pageNumber: Number(pageNumber),
-      pageCount: Number(pageCount),
-      isTestBallot: false,
-    })
+    id: () => ballotFile,
+    imageData: () => readImageData(ballotFile),
+    metadata: async () =>
+      metadataFile
+        ? JSON.parse(await fs.readFile(metadataFile, 'utf-8'))
+        : undefined,
   }
   return input
 }


### PR DESCRIPTION
BREAKING CHANGE. Previously the metadata would be specified as colon-separated values. This was becoming unweildy as we added more metadata values. Now we accept a JSON metadata filename.