### PR TITLE
fix: ensure write-in options have unique ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ const interpreter = new Interpreter({
 
 ```sh
 # To try this example out, install globally then clone the repository and `cd`
-# to `test/fixtures/election-4e31cb17d8f2f3bac574c6d2f6e22fb2528dcdf8-ballot-style-77-precinct-oaklawn-branch-library`.
+# to `test/fixtures/election-4e31cb17d8-ballot-style-77-precinct-oaklawn-branch-library`.
 $ hmpb interpret -e election.json \
   blank-p1.jpg \
   blank-p2.jpg \
@@ -140,7 +140,7 @@ $ hmpb interpret -e election.json -f \
         ],
         "texas-house-district-111": [
           {
-            "id": "__write-in",
+            "id": "__write-in-0",
             "name": "Write-In",
             "isWriteIn": true
           }
@@ -269,7 +269,7 @@ $ hmpb interpret -e election.json -f \
         {
           "type": "candidate",
           "contest": "texas-house-district-111",
-          "option": "__write-in",
+          "option": "__write-in-0",
           "score": 0.7025,
           "bounds": {
             "x": 872,
@@ -501,7 +501,7 @@ $ hmpb interpret -e election.json -f \
         {
           "type": "candidate",
           "contest": "dallas-city-council",
-          "option": "__write-in",
+          "option": "__write-in-1",
           "score": 0.09595959595959595,
           "bounds": {
             "x": 470,
@@ -527,7 +527,7 @@ $ hmpb interpret -e election.json -f \
         {
           "type": "candidate",
           "contest": "dallas-city-council",
-          "option": "__write-in",
+          "option": "__write-in-2",
           "score": 0.01015228426395939,
           "bounds": {
             "x": 470,

--- a/src/Interpreter.test.ts
+++ b/src/Interpreter.test.ts
@@ -654,7 +654,7 @@ test('interpret votes', async () => {
       ],
       "texas-house-district-111": Array [
         Object {
-          "id": "__write-in",
+          "id": "__write-in-0",
           "isWriteIn": true,
           "name": "Write-In",
         },
@@ -1014,7 +1014,7 @@ test('invalid marks', async () => {
           "type": "candidate",
         },
         "option": Object {
-          "id": "__write-in",
+          "id": "__write-in-0",
           "isWriteIn": true,
           "name": "Write-In",
         },
@@ -1069,7 +1069,7 @@ test('invalid marks', async () => {
           "type": "candidate",
         },
         "option": Object {
-          "id": "__write-in",
+          "id": "__write-in-1",
           "isWriteIn": true,
           "name": "Write-In",
         },
@@ -1691,7 +1691,7 @@ test('invalid marks', async () => {
           "type": "candidate",
         },
         "option": Object {
-          "id": "__write-in",
+          "id": "__write-in-0",
           "isWriteIn": true,
           "name": "Write-In",
         },
@@ -1761,7 +1761,7 @@ test('invalid marks', async () => {
           "type": "candidate",
         },
         "option": Object {
-          "id": "__write-in",
+          "id": "__write-in-1",
           "isWriteIn": true,
           "name": "Write-In",
         },
@@ -1831,7 +1831,7 @@ test('invalid marks', async () => {
           "type": "candidate",
         },
         "option": Object {
-          "id": "__write-in",
+          "id": "__write-in-2",
           "isWriteIn": true,
           "name": "Write-In",
         },
@@ -1981,7 +1981,7 @@ test('invalid marks', async () => {
           "type": "candidate",
         },
         "option": Object {
-          "id": "__write-in",
+          "id": "__write-in-0",
           "isWriteIn": true,
           "name": "Write-In",
         },
@@ -2059,7 +2059,7 @@ test('upside-down ballot', async () => {
       ],
       "texas-house-district-111": Array [
         Object {
-          "id": "__write-in",
+          "id": "__write-in-0",
           "isWriteIn": true,
           "name": "Write-In",
         },

--- a/src/Interpreter.ts
+++ b/src/Interpreter.ts
@@ -527,7 +527,10 @@ export default class Interpreter {
         if (contest.allowWriteIns) {
           const writeInOptions = options.slice(contest.candidates.length)
 
-          for (const writeInOption of writeInOptions) {
+          for (const [
+            writeInIndex,
+            writeInOption,
+          ] of writeInOptions.entries()) {
             const score = this.targetMarkScore(
               template.ballotImage.imageData,
               mappedBallot,
@@ -540,7 +543,7 @@ export default class Interpreter {
               score,
               target: writeInOption.target,
               option: {
-                id: '__write-in',
+                id: `__write-in-${writeInIndex}`,
                 name: 'Write-In',
                 isWriteIn: true,
               },

--- a/test/regression/28lb-paper.test.ts
+++ b/test/regression/28lb-paper.test.ts
@@ -108,7 +108,7 @@ test('batch-1-20200504_210852-ballot-0002', async () => {
       ],
       "texas-house-district-111": Array [
         Object {
-          "id": "__write-in",
+          "id": "__write-in-0",
           "isWriteIn": true,
           "name": "Write-In",
         },
@@ -770,7 +770,7 @@ test('batch-1-20200504_210852-ballot-0014', async () => {
       ],
       "texas-house-district-111": Array [
         Object {
-          "id": "__write-in",
+          "id": "__write-in-0",
           "isWriteIn": true,
           "name": "Write-In",
         },


### PR DESCRIPTION
This is not indended to carry through all the way to CVRs, but will make adjudicating marks easier.