### PR TITLE
fix: do not require all templates on CLI when providing metadata

### DIFF
--- a/src/cli/commands/interpret.ts
+++ b/src/cli/commands/interpret.ts
@@ -156,11 +156,12 @@ export default async function run(
   }
 
   for (const autoInput of options.autoInputs) {
-    if (interpreter.hasMissingTemplates()) {
-      await interpreter.addTemplate(
-        await autoInput.imageData(),
-        await autoInput.metadata?.()
-      )
+    const metadata = await autoInput.metadata?.()
+    if (
+      !(metadata && interpreter.canScanBallot(metadata)) ||
+      interpreter.hasMissingTemplates()
+    ) {
+      await interpreter.addTemplate(await autoInput.imageData(), metadata)
     } else {
       ballotInputs.push(autoInput)
     }


### PR DESCRIPTION
Ideally we'd also allow checking the QR code to read the metadata to make this check, but for now this is at least better.