### PR TITLE
feat: add support for representing ms-either-neither contests

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
-    "@votingworks/ballot-encoder": "^2.2.0",
+    "@votingworks/ballot-encoder": "^3.0.0",
     "canvas": "^2.6.1",
     "chalk": "^4.0.0",
     "debug": "^4.1.1",

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,13 @@
 import {
+  AnyContest,
   BallotStyle,
   Candidate,
   CandidateContest,
   CompletedBallot,
+  MsEitherNeitherContest,
   Precinct,
   YesNoContest,
+  YesNoOption,
 } from '@votingworks/ballot-encoder'
 import { TargetShape } from './hmpb/findTargets'
 
@@ -86,14 +89,17 @@ export type BallotMark = BallotStrayMark | BallotTargetMark
 export interface BallotStrayMark {
   type: 'stray'
   bounds: Rect
-  contest?: YesNoContest | CandidateContest
-  option?: Candidate | 'yes' | 'no'
+  contest?: AnyContest
+  option?: Candidate | 'yes' | 'no' | YesNoOption
 }
 
-export type BallotTargetMark = BallotCandidateTargetMark | BallotYesNoTargetMark
+export type BallotTargetMark =
+  | BallotCandidateTargetMark
+  | BallotYesNoTargetMark
+  | BallotMsEitherNeitherTargetMark
 
 export interface BallotCandidateTargetMark {
-  type: 'candidate'
+  type: CandidateContest['type']
   bounds: Rect
   contest: CandidateContest
   target: TargetShape
@@ -102,11 +108,20 @@ export interface BallotCandidateTargetMark {
 }
 
 export interface BallotYesNoTargetMark {
-  type: 'yesno'
+  type: YesNoContest['type']
   bounds: Rect
   contest: YesNoContest
   target: TargetShape
   option: 'yes' | 'no'
+  score: number
+}
+
+export interface BallotMsEitherNeitherTargetMark {
+  type: MsEitherNeitherContest['type']
+  bounds: Rect
+  contest: MsEitherNeitherContest
+  target: TargetShape
+  option: YesNoOption
   score: number
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -676,10 +676,10 @@
     semver "^6.3.0"
     tsutils "^3.17.1"
 
-"@votingworks/ballot-encoder@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@votingworks/ballot-encoder/-/ballot-encoder-2.2.0.tgz#92400d3165e87538d324c678cd7d63be47a23fc3"
-  integrity sha512-o0nxhQkbNXupGH8Mh3lfyugz33luhKPvmow1gfKcVzoSTJP7fw2/C/gmZnrSkqFiZisEsbW223FyUbgiaR7+UQ==
+"@votingworks/ballot-encoder@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@votingworks/ballot-encoder/-/ballot-encoder-3.0.0.tgz#c82ce28b184ff3828d393b11928517021a6ce855"
+  integrity sha512-IK8wkd0uT6XSjlakvYOthzbEC701ycVU0C050nudNL3+TTCCa6Xtz2x69xOXVedCn0fCo2vrJ5c8OveoFqeFPg==
   dependencies:
     "@antongolub/iso8601" "^1.2.1"
     zod "^1.7.1"


### PR DESCRIPTION
This does not guarantee that we'll be able to interpret them, but if they follow the same shape as other contests we should be able to find all the options. It assumes the order of answers is either/neither/first/second.