### PR TITLE
fix: be smarter about column sizes

### DIFF
--- a/src/hmpb/findContests.ts
+++ b/src/hmpb/findContests.ts
@@ -13,17 +13,27 @@ export interface ContestShape {
   corners: Corners
 }
 
+export interface Options {
+  inset?: number
+  columns?: readonly boolean[]
+  minContestWidthPercent?: number
+  minContestHeightPercent?: number
+  maxContestWidthPercent?: number
+  maxContestHeightPercent?: number
+  maxTopContestOffsetPercent?: number
+}
+
 export default function* findContests(
   ballotImage: ImageData,
   {
     inset = 0,
-    minContestWidthPercent = 20,
+    columns = [true, true, true],
+    minContestWidthPercent = Math.floor(100 / columns.length) - 5,
     minContestHeightPercent = 10,
-    maxContestWidthPercent = 40,
+    maxContestWidthPercent = Math.ceil(100 / columns.length) + 5,
     maxContestHeightPercent = 90,
     maxTopContestOffsetPercent = 10,
-    columns = [true, true, true],
-  } = {}
+  }: Options = {}
 ): Generator<ContestShape> {
   const bounds: Rect = {
     x: inset,


### PR DESCRIPTION
We should base the expected contest width on the number of columns by default. When there are three columns, we now expect a contest box to be between 28-39% vs 20-40% previously. If only two columns are given, it'd be 45-55%. More work will likely need to be done to support two-column layouts, but this is a fairly obvious start.