### PR TITLE
fix: prevent infinite loop looking for corners

### DIFF
--- a/src/utils/corners.test.ts
+++ b/src/utils/corners.test.ts
@@ -1,6 +1,7 @@
 import * as oaklawn from '../../test/fixtures/election-4e31cb17d8-ballot-style-77-precinct-oaklawn-branch-library'
 import * as walthall2020 from '../../test/fixtures/walthall-county-2020-general-election-6f6f9cdb30'
 import * as choctaw from '../../test/fixtures/choctaw-county-2020-general-election'
+import * as hamilton from '../../test/fixtures/election-5c6e578acf-state-of-hamilton-2020'
 import { binarize } from './binarize'
 import { getCorners } from './corners'
 
@@ -139,6 +140,41 @@ test('regression: choctaw county filled-in-p1-01', async () => {
       Object {
         "x": 1661,
         "y": 2887,
+      },
+    ]
+  `)
+})
+
+test('regression: state of hamilton p4', async () => {
+  const imageData = await hamilton.filledInPage4.imageData()
+  binarize(imageData)
+
+  expect(
+    getCorners(imageData, {
+      bounds: {
+        height: 1737,
+        width: 735,
+        x: 907,
+        y: 140,
+      },
+    })
+  ).toMatchInlineSnapshot(`
+    Array [
+      Object {
+        "x": 908,
+        "y": 141,
+      },
+      Object {
+        "x": 1641,
+        "y": 141,
+      },
+      Object {
+        "x": 908,
+        "y": 1874,
+      },
+      Object {
+        "x": 1640,
+        "y": 1874,
       },
     ]
   `)


### PR DESCRIPTION
I wasn't doing proper bounds checking on the x,y values, so in some conditions we might go beyond the bounding box looking for black pixels. In some cases, we'd even go outside the bounds of the image. Once that happens, we'd loop forever since the pixel value at such points is `undefined`, which will never equal 0.

This happened because we were looking for TWO consecutive black pixels along the edge of the bounding box in either direction. However, there only has to be ONE consecutive pixel for it to push the bounding box out. This is the case that would cause the corner finder to keep going beyond the bounding box and possibly forever.

Finding two consecutive pixels was from before I implemented backtracking, and no longer seems necessary. Once we find a single black pixel we can backtrack to find the real corner. Additionally, I added bounds checking since we have no reason to leave the bounding box looking for corners.