### PR TITLE
fix: ensure single-contest pages scan correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@votingworks/hmpb-interpreter",
-  "version": "5.2.4",
+  "version": "5.2.5",
   "description": "Interprets hand-marked paper ballots.",
   "repository": "https://github.com/votingworks/hmpb-interpreter",
   "license": "GPL-3.0",


### PR DESCRIPTION
Building a homography requires at least three points, so we can't just use the left two corners of the single contest box on a page. In that case, use all four corners.