### PR TITLE
fix: use all four contest corners on 2-column pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@votingworks/hmpb-interpreter",
-  "version": "5.2.5",
+  "version": "5.2.6",
   "description": "Interprets hand-marked paper ballots.",
   "repository": "https://github.com/votingworks/hmpb-interpreter",
   "license": "GPL-3.0",


### PR DESCRIPTION
On 2-column pages the contests are wide enough that the skew on the right side can cause problems with the left side lining up, even though we got the left corners lined up. This has led to spurious overvotes on the tall+wide either-neither contest in the upcoming general election in MS. This change was tested with 3798 scans, and it went from 91 either-neither overvotes to 2 either-neither overvotes.
